### PR TITLE
Avoid an error on mapping on the final class channel, use the interface instead

### DIFF
--- a/src/Resources/config/doctrine/Homepage.orm.xml
+++ b/src/Resources/config/doctrine/Homepage.orm.xml
@@ -10,7 +10,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\Channel">
+        <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
             <join-table name="monsieurbiz_homepage_homepage_channels">
                 <join-columns>
                     <join-column name="page_id" referenced-column-name="id" />


### PR DESCRIPTION
On my PHP 8.1 project, I have an error detected by the `console doctrine:schema:validate` command on the mapping:

![image](https://github.com/monsieurbiz/SyliusHomepagePlugin/assets/465524/c1ddd43d-c53b-4feb-a464-e90666c4fe6a)
