### PR TITLE
Add permission on routes in case of Sylius Plus

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -2,6 +2,7 @@ monsieurbiz_sylius_homepage_admin:
     resource: |
         alias: monsieurbiz_homepage.homepage
         section: admin
+        permission: true
         templates: "@SyliusAdmin\\Crud"
         except: ['show']
         redirect: update

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -17,3 +17,7 @@ monsieurbiz_homepage:
             id: 'ID'
         actions:
             create: 'New homepage'
+sylius_plus:
+    rbac:
+        parent:
+            homepages: 'Homepages'            

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -17,3 +17,7 @@ monsieurbiz_homepage:
             id: 'ID'
         actions:
             create: 'Nouvelle page d''accueil'
+sylius_plus:
+    rbac:
+        parent:
+            homepages: 'Homepages'

--- a/src/Resources/translations/messages.nl.yaml
+++ b/src/Resources/translations/messages.nl.yaml
@@ -17,3 +17,7 @@ monsieurbiz_homepage:
             id: 'ID'
         actions:
             create: 'Nieuwe homepagina'
+sylius_plus:
+    rbac:
+        parent:
+            homepages: 'Homepagina''s'


### PR DESCRIPTION
Add permission on routes so the RBAC of Sylius Plus can put be used for the routes of the plugin.

For Sylius Standard it's changing nothing.